### PR TITLE
Add scaleX and scaleY variants

### DIFF
--- a/Pod/Classes/SKEase.swift
+++ b/Pod/Classes/SKEase.swift
@@ -133,6 +133,20 @@ open class SKEase {
         }
         return action
     }
+    open class func scaleX(easeFunction curve:CurveType, easeType:EaseType, time:TimeInterval, from:CGFloat, to:CGFloat)->SKAction {
+        let easingFunction = SKEase.getEaseFunction(curve, easeType: easeType)
+        let action = self.createFloatTween(from, end: to, time: time, easingFunction: easingFunction) { (node:SKNode, scale:CGFloat) -> Void in
+            node.xScale = scale
+        }
+        return action
+    }
+    open class func scaleY(easeFunction curve:CurveType, easeType:EaseType, time:TimeInterval, from:CGFloat, to:CGFloat)->SKAction {
+        let easingFunction = SKEase.getEaseFunction(curve, easeType: easeType)
+        let action = self.createFloatTween(from, end: to, time: time, easingFunction: easingFunction) { (node:SKNode, scale:CGFloat) -> Void in
+            node.yScale = scale
+        }
+        return action
+    }
     ///legacy
     open class func scaleToWithNode(_ target:SKNode, easeFunction curve:CurveType, easeType:EaseType, time:TimeInterval, toValue to:CGFloat)->SKAction {
         let easingFunction = SKEase.getEaseFunction(curve, easeType: easeType)

--- a/Pod/Classes/SKEase.swift
+++ b/Pod/Classes/SKEase.swift
@@ -133,6 +133,14 @@ open class SKEase {
         }
         return action
     }
+    /**
+     Animate scale X
+     - parameter easeFunction: Curve type
+     - parameter easeType: Ease type
+     - parameter time: duration of tween
+     - parameter from: initial scale X
+     - parameter to: destination scale X
+     */
     open class func scaleX(easeFunction curve:CurveType, easeType:EaseType, time:TimeInterval, from:CGFloat, to:CGFloat)->SKAction {
         let easingFunction = SKEase.getEaseFunction(curve, easeType: easeType)
         let action = self.createFloatTween(from, end: to, time: time, easingFunction: easingFunction) { (node:SKNode, scale:CGFloat) -> Void in
@@ -140,6 +148,14 @@ open class SKEase {
         }
         return action
     }
+    /**
+     Animate scale Y
+     - parameter easeFunction: Curve type
+     - parameter easeType: Ease type
+     - parameter time: duration of tween
+     - parameter from: initial scale Y
+     - parameter to: destination scale Y
+     */
     open class func scaleY(easeFunction curve:CurveType, easeType:EaseType, time:TimeInterval, from:CGFloat, to:CGFloat)->SKAction {
         let easingFunction = SKEase.getEaseFunction(curve, easeType: easeType)
         let action = self.createFloatTween(from, end: to, time: time, easingFunction: easingFunction) { (node:SKNode, scale:CGFloat) -> Void in


### PR DESCRIPTION
Sometimes you dont want to scale the entire node :)

![mar-01-2017 23-31-18](https://cloud.githubusercontent.com/assets/384976/23486316/578576e8-fed7-11e6-848b-e73cd9143ed7.gif)

Using scaleX to scale down, switch texture and scale up again to imitate flipping a card.